### PR TITLE
fix bug by adding then.catch for controllerFn

### DIFF
--- a/server/router/api/v2/routeBuilder/core/util/registerController.js
+++ b/server/router/api/v2/routeBuilder/core/util/registerController.js
@@ -11,6 +11,15 @@ import { config } from "../config.js";
  * @returns 
  */
 export async function registerController(res, next, controllerFn, options={}) {
-    res[options.respFieldName ?? config.respFieldName] = await controllerFn();
+    const [isError, resp] = await controllerFn().then((result) => {
+        return [false, result];
+    }).catch((err) => {
+        return [true, err];
+    });
+
+    if(isError)
+        return next(resp);
+
+    res[options.respFieldName ?? config.respFieldName] = resp;
     return next();
 }


### PR DESCRIPTION
Fixes #38 
The bug was because in case of errors happened in  the pipeline (the controller function), these thrown errors should be passed as next() argument