### PR TITLE
Fix updating traffic situation 

### DIFF
--- a/server/service/AreaService.js
+++ b/server/service/AreaService.js
@@ -66,7 +66,7 @@ export default class AreaService {
      * @returns true if operation was successful or false if not
      */
     async delete(primaryKey) {
-        return this.service.deleteById(primaryKey, areaName);
+        return this.service.deleteByCondition({where: {areaName: primaryKey}});
     }
 
     async deleteAllCityCenters() {

--- a/server/util/settings/SettingsUtil.js
+++ b/server/util/settings/SettingsUtil.js
@@ -105,7 +105,7 @@ async function convertCityCentersFileToGeoJson(filePath) {
 
 export async function updateTrafficSituation(maxAcceptableValue){
     const areaName = 'SlowTraffic';
-    areaDAO.delete(areaName);
+    await areaDAO.delete(areaName);
 
     const slowStationIds = await getSlowTMSIds(maxAcceptableValue);
     const stationPolygon = await tmsDAO.readMultipleByIds(slowStationIds);


### PR DESCRIPTION
There was two problems causing this bug:
1. The delete() of AreaService was trying to delete the TMS area by id (which does not exists) not by areaName field.
2. In the updateTrafficSituation() there was not an await statement for the Area delete() call

Fixes #52 